### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/create-dotnet-versions.yml
+++ b/.github/workflows/create-dotnet-versions.yml
@@ -14,7 +14,7 @@ jobs:
     name: Test the create-dotnet-versions locally
     steps:
       - name: Checkout
-        uses: actions/checkout@v3    
+        uses: actions/checkout@v3.2.0    
       - name: Create version step
         id: create-version
         uses: ./create-dotnet-versions

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.2.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.2.0](https://github.com/actions/checkout/releases/tag/v3.2.0)** on 2022-12-12T19:14:01Z
